### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,5 +1,7 @@
 ---
 name: Lint
+permissions:
+  contents: read
 
 # yamllint disable-line rule:truthy
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/elcajon-dev/repository-stable/security/code-scanning/2](https://github.com/elcajon-dev/repository-stable/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function. Since the workflow is for linting, it likely only needs `contents: read` permissions. This ensures that the `GITHUB_TOKEN` is restricted to read-only access to the repository contents, minimizing the risk of unintended actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
