### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/repository-updater.yaml
+++ b/.github/workflows/repository-updater.yaml
@@ -14,6 +14,8 @@ jobs:
   publish:
     name: Publish add-on update
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: 🔐 Load 1Password secrets
         uses: 1password/load-secrets-action@581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0 # v2.0.0


### PR DESCRIPTION
Potential fix for [https://github.com/elcajon-dev/repository-stable/security/code-scanning/1](https://github.com/elcajon-dev/repository-stable/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow appears to interact with repository contents (e.g., using a token for updates), we will grant `contents: read` at a minimum. If the workflow requires additional permissions (e.g., `contents: write` for modifying repository contents), we will include them explicitly. The `permissions` block will be added at the job level to ensure it applies only to the `publish` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
